### PR TITLE
Enable network expansion macros

### DIFF
--- a/src/DiffEqBiological.jl
+++ b/src/DiffEqBiological.jl
@@ -15,7 +15,7 @@ include("expression_utils.jl")
 include("reaction_network.jl")
 
 # reaction network macro
-export @reaction_network
+export @reaction_network, @add_reactions
 export @reaction_func
 
 

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -86,10 +86,10 @@ end
 """
     ==(rn1::ModelingToolkit.Reaction, rn2::ModelingToolkit.Reaction)
 
-Tests whether two `ModelingToolkit.Reaction`s are identical. 
+Tests whether two `ModelingToolkit.Reaction`s are identical.
 
 Notes:
-- Ignores the order in which stoichiometry components are listed. 
+- Ignores the order in which stoichiometry components are listed.
 - *Does not* currently simplify rates, so a rate of `A^2+2*A+1` would be
 considered different than `(A+1)^2`.
 """
@@ -106,7 +106,7 @@ end
     ==(rn1::ReactionSystem, rn2::ReactionSystem)
 
 Tests whether the underlying species `Variables`s, parameter `Variables`s and reactions
-are the same in the two networks. Ignores order network components were defined. 
+are the same in the two networks. Ignores order network components were defined.
 
 Notes:
 - *Does not* currently simplify rates, so a rate of `A^2+2*A+1` would be considered
@@ -117,12 +117,12 @@ function (==)(rn1::ReactionSystem, rn2::ReactionSystem)
     issetequal(params(rn1), params(rn2)) || return false
     isequal(rn1.iv, rn2.iv) || return false
     (numreactions(rn1) == numreactions(rn2)) || return false
-    
+
     # the following fails for some reason, so need to use issubset
-    #issetequal(equations(rn1), equations(rn2)) || return false    
+    #issetequal(equations(rn1), equations(rn2)) || return false
     (issubset(equations(rn1),equations(rn2)) && issubset(equations(rn2),equations(rn1))) || return false
-    
-    #issetequal(rn1.systems, rn2.systems) || return false    
+
+    #issetequal(rn1.systems, rn2.systems) || return false
     sys1 = rn1.systems; sys2 = rn2.systems
     (issubset(sys1,sys2) && issubset(sys2,sys1)) || return false
     true
@@ -144,7 +144,7 @@ end
     addspecies!(network::ReactionSystem, s::Variable)
 
 Given a `ReactionSystem`, add the species corresponding to the variable `s`
-to the network (if it is not already defined). Returns the integer id 
+to the network (if it is not already defined). Returns the integer id
 of the species within the system.
 """
 function addspecies!(network::ReactionSystem, s::Variable)
@@ -154,26 +154,46 @@ function addspecies!(network::ReactionSystem, s::Variable)
         return length(species(network))
     else
         return curidx
-    end    
+    end
 end
 
 """
     addspecies!(network::ReactionSystem, s::Operation)
 
 Given a `ReactionSystem`, add the species corresponding to the variable `s`
-to the network (if it is not already defined). Returns the integer id 
+to the network (if it is not already defined). Returns the integer id
 of the species within the system.
 """
-function addspecies!(network::ReactionSystem, s::Operation) 
-    !(s.op isa Variable) && error("If the passed in species is an Operation, it must correspond to an underlying Variable.")        
-    addspecies!(network, convert(Variable,s))    
+function addspecies!(network::ReactionSystem, s::Operation)
+    !(s.op isa Variable) && error("If the passed in species is an Operation, it must correspond to an underlying Variable.")
+    addspecies!(network, convert(Variable,s))
+end
+
+"""
+    addspecies!(network::ReactionSystem, ss::Union(Vector{Variable},Tuple{Variable}))
+
+Given a `ReactionSystem`, add all the species corresponding to the variables in `ss`
+to the network (if it is not already defined). Returns nothing.
+"""
+function addspecies!(network::ReactionSystem, ss::Union(Vector{Variable},Tuple{Variable}))
+    foreach(s -> addspecies!(network,s), ss)
+end
+
+"""
+    addspecies!(network::ReactionSystem, ss::Union(Vector{Operation},Tuple{Operation}))
+
+Given a `ReactionSystem`, add all the species corresponding to the variables in `ss`
+to the network (if it is not already defined). Returns nothing.
+"""
+function addspecies!(network::ReactionSystem, ss::Union(Vector{Operation},Tuple{Operation}))
+    foreach(s -> addspecies!(network,s), ss)
 end
 
 """
     addparam!(network::ReactionSystem, p::Variable)
 
 Given a `ReactionSystem`, add the parameter corresponding to the variable `p`
-to the network (if it is not already defined). Returns the integer id 
+to the network (if it is not already defined). Returns the integer id
 of the parameter within the system.
 """
 function addparam!(network::ReactionSystem, p::Variable)
@@ -183,19 +203,39 @@ function addparam!(network::ReactionSystem, p::Variable)
         return length(params(network))
     else
         return curidx
-    end    
+    end
 end
 
 """
     addparam!(network::ReactionSystem, p::Operation)
 
 Given a `ReactionSystem`, add the parameter corresponding to the variable `p`
-to the network (if it is not already defined). Returns the integer id 
+to the network (if it is not already defined). Returns the integer id
 of the parameter within the system.
 """
-function addparam!(network::ReactionSystem, p::Operation) 
-    !(p.op isa Variable) && error("If the passed in parameter is an Operation, it must correspond to an underlying Variable.")        
-    addparam!(network, convert(Variable,p))    
+function addparam!(network::ReactionSystem, p::Operation)
+    !(p.op isa Variable) && error("If the passed in parameter is an Operation, it must correspond to an underlying Variable.")
+    addparam!(network, convert(Variable,p))
+end
+
+"""
+    addparam!(network::ReactionSystem, ps::Union(Vector{Variable},Tuple{Variable}))
+
+Given a `ReactionSystem`, add all the parameters corresponding to the variables in `ps`
+to the network (if it is not already defined). Returns nothing.
+"""
+function addparam!(network::ReactionSystem, ps::Union(Vector{Variable},Tuple{Variable}))
+    foreach(p -> addparam!(network,p), ps)
+end
+
+"""
+    addparam!(network::ReactionSystem, ps::Union(Vector{Operation},Tuple{Operation}))
+
+Given a `ReactionSystem`, add all the parameters corresponding to the variables in `ps`
+to the network (if it is not already defined). Returns nothing.
+"""
+function addparam!(network::ReactionSystem, ps::Union(Vector{Operation},Tuple{Operation}))
+    foreach(p -> addparam!(network,p), ps)
 end
 
 """
@@ -204,11 +244,11 @@ end
 Add the passed in reaction to the `ReactionSystem`. Returns the integer
 id of `rx` in the list of `Reaction`s within `network`.
 
-Notes: 
+Notes:
 - Any new species or parameters used in `rx` should be separately added
 to `network` using [`addspecies!`](@ref) and [`addparams!`](@ref).
 """
-function addreaction!(network::ReactionSystem, rx::Reaction)    
+function addreaction!(network::ReactionSystem, rx::Reaction)
     push!(network.eqs, rx)
     length(equations(network))
 end

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -170,26 +170,6 @@ function addspecies!(network::ReactionSystem, s::Operation)
 end
 
 """
-    addspecies!(network::ReactionSystem, ss::Union(Vector{Variable},Tuple{Variable}))
-
-Given a `ReactionSystem`, add all the species corresponding to the variables in `ss`
-to the network (if it is not already defined). Returns nothing.
-"""
-function addspecies!(network::ReactionSystem, ss::Union(Vector{Variable},Tuple{Variable}))
-    foreach(s -> addspecies!(network,s), ss)
-end
-
-"""
-    addspecies!(network::ReactionSystem, ss::Union(Vector{Operation},Tuple{Operation}))
-
-Given a `ReactionSystem`, add all the species corresponding to the variables in `ss`
-to the network (if it is not already defined). Returns nothing.
-"""
-function addspecies!(network::ReactionSystem, ss::Union(Vector{Operation},Tuple{Operation}))
-    foreach(s -> addspecies!(network,s), ss)
-end
-
-"""
     addparam!(network::ReactionSystem, p::Variable)
 
 Given a `ReactionSystem`, add the parameter corresponding to the variable `p`
@@ -216,26 +196,6 @@ of the parameter within the system.
 function addparam!(network::ReactionSystem, p::Operation)
     !(p.op isa Variable) && error("If the passed in parameter is an Operation, it must correspond to an underlying Variable.")
     addparam!(network, convert(Variable,p))
-end
-
-"""
-    addparam!(network::ReactionSystem, ps::Union(Vector{Variable},Tuple{Variable}))
-
-Given a `ReactionSystem`, add all the parameters corresponding to the variables in `ps`
-to the network (if it is not already defined). Returns nothing.
-"""
-function addparam!(network::ReactionSystem, ps::Union(Vector{Variable},Tuple{Variable}))
-    foreach(p -> addparam!(network,p), ps)
-end
-
-"""
-    addparam!(network::ReactionSystem, ps::Union(Vector{Operation},Tuple{Operation}))
-
-Given a `ReactionSystem`, add all the parameters corresponding to the variables in `ps`
-to the network (if it is not already defined). Returns nothing.
-"""
-function addparam!(network::ReactionSystem, ps::Union(Vector{Operation},Tuple{Operation}))
-    foreach(p -> addparam!(network,p), ps)
 end
 
 """

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -78,8 +78,8 @@ end
 
 #Returns a empty network (with, or without, parameters declared)
 macro reaction_network(parameters...)
-    !isempty(intersect(forbidden_symbols,parameters)) && error("The following symbol(s) are used as reactants or parameters: "*((map(s -> "'"*string(s)*"', ",intersect(forbidden_symbols,parameters))...))*"this is not permited.")
-    return :(ReactionSystem(Reaction[], Variable(:t), Operation[], Variable.(collect(parameters)), gensym(:ReactionSystem), ReactionSystem[]))
+    !isempty(intersect(forbidden_symbols,parameters)) && error("The following symbol(s) are used as reactants or parameters: "*((map(s -> "'"*string(s)*"', ",intersect(forbidden_symbols,reactants,parameters))...))*"this is not permited.")
+    return Expr(:block,:(@parameters $((:t,parameters...)...)), :(ReactionSystem(Reaction[], t, Operation[], [$(parameters...)] , gensym(:ReactionSystem), ReactionSystem[])))
 end
 
 # Adds the reactions declared to a preexisting network. All parameters used in the added reactions needs to be declared after the reactions.

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -54,7 +54,7 @@ Example systems:
 
 Generates a `ModelingToolkit.ReactionSystem` that encodes a chemical reaction network.
 
-See the [Chemical Reaction Model docs](http://docs.sciml.ai/dev/models/biological.html) 
+See the [Chemical Reaction Model docs](http://docs.sciml.ai/dev/models/biological.html)
 for details on parameters to the macro.
 """
 
@@ -74,14 +74,19 @@ macro reaction_network(ex::Expr, parameters...)
     make_reaction_system(MacroTools.striplines(ex), parameters)
 end
 
-# Returns a empty network (with, or without, parameters declared)
+### Macros used for manipulating, and successively builing up, reaction systems. ###
+
+#Returns a empty network (with, or without, parameters declared)
 macro reaction_network(parameters...)
-    !isempty(intersect(forbidden_symbols,parameters)) && error("The following symbol(s) are used as parameter(s): "*((map(s -> "'"*string(s)*"', ",intersect(forbidden_symbols,parameters))...))*"this is not permited.")
-    network_code = Expr(:block,:(@parameters t),[], :(ReactionSystem([],t,[],[])))
-    foreach(parameter-> push!(network_code.args[1].args, parameter), parameters)
-    foreach(parameter-> push!(network_code.args[3].args[5].args, parameter), parameters)
-    return network_code
+    !isempty(intersect(forbidden_symbols,parameters)) && error("The following symbol(s) are used as reactants or parameters: "*((map(s -> "'"*string(s)*"', ",intersect(forbidden_symbols,parameters))...))*"this is not permited.")
+    return :(ReactionSystem(Reaction[], Variable(:t), Operation[], Variable.(collect(parameters)), gensym(:ReactionSystem), ReactionSystem[]))
 end
+
+# Adds the reactions declared to a preexisting network. All parameters used in the added reactions needs to be declared after the reactions.
+macro add_reactions(rn::Symbol, ex::Expr, parameters...)
+    :(merge!($(esc(rn)),$(make_reaction_system(MacroTools.striplines(ex), parameters))))
+end
+
 
 
 ### Sturctures containing information about a reactant, and a reaction, respectively.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,7 +15,6 @@ using SafeTestsets
 # Tests various core properties of the package.
 @time @safetestset "Higher Order" begin include("higher_order_reactions.jl") end
 @time @safetestset "U0 and Parameters Input Types" begin include("u0_n_parameter_inputs.jl") end
-#@time @safetestset "Network Property Queries" begin include("property_query.jl") end
 
 # Tests related to solving Ordinary Differential Equations.
 @time @safetestset "ODE System Solving" begin include("solve_ODEs.jl") end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ using SafeTestsets
 # Tests all features realted to constructing a model
 @time @safetestset "Model Construction" begin include("make_model.jl") end
 @time @safetestset "Custom Functions" begin include("custom_functions.jl") end
-#@time @safetestset "Model Modification" begin include("model_modification.jl") end
+@time @safetestset "Model Modification" begin include("model_modification.jl") end
 
 # Test api
 @time @safetestset "API" begin include("api.jl") end


### PR DESCRIPTION
This builds on https://github.com/SciML/DiffEqBiological.jl/pull/199 by allowing you to reach some of the functionality using the macro. Now:
```julia
rn = @reaction_network
```
creates an empty reaction network.
```julia
rn = @reaction_network p1 p2 p3
```
creates an empty reaction network, and loads it with the parameters `p1`, `p2`, and `p3`.

Also, the macro `@add_reactions` is added, where
```julia
rn = @reaction_network begin
   (k1,k2), X ↔ Y
end k1 k2
@add_reactions rn begin
   (p,d), X ↔ ∅
end p d
```
is equivalent to
```julia
rn = @reaction_network begin
   (k1,k2), X ↔ Y
   (p,d), X ↔ ∅
end k1 k2 p d
```
parameters can be declared repeatedly without worry, however, whenever reactions are added, all parameters used have to be marked. E.g. this
```julia
rn = @reaction_network begin
   (k1,k2), X ↔ Y
end k1 k2 p d
@add_reactions rn begin
   (p,d), X ↔ ∅
end p d
```
is fine, while 
```julia
rn = @reaction_network begin
   (k1,k2), X ↔ Y
end k1 k2 p d
@add_reactions rn begin
   (p,d), X ↔ ∅
end 
```
is not.