### PR TITLE
Allow I as a variable and remove unneeded imports

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,32 +3,20 @@ uuid = "eb300fae-53e8-50a0-950c-e21f52c2b7e0"
 version = "4.3.0"
 
 [deps]
-Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
-DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
-DiffEqJump = "c894b116-72e5-5b58-be3c-e6d8d4ac2b12"
-Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
-RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
-Compat = "2.2, 3.0"
-DataStructures = "0.17"
-DiffEqBase = "6"
-DiffEqJump = "6"
-Latexify = "0.11, 0.12, 0.13"
 MacroTools = "0.5"
-ModelingToolkit = "3.7"
-RecipesBase = "0.7, 0.8, 1.0"
+ModelingToolkit = "3.13"
 Reexport = "0.2"
-julia = "1.1"
+julia = "1.3"
 
 [extras]
+DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
+DiffEqJump = "c894b116-72e5-5b58-be3c-e6d8d4ac2b12"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
-Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
@@ -38,4 +26,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [targets]
-test = ["OrdinaryDiffEq", "Plots", "Random", "SafeTestsets", "Statistics", "SteadyStateDiffEq", "StochasticDiffEq", "Test", "UnPack"]
+test = ["DiffEqBase","DiffEqJump","OrdinaryDiffEq","Random","SafeTestsets", "Statistics", "SteadyStateDiffEq", "StochasticDiffEq", "Test", "UnPack"]

--- a/src/DiffEqBiological.jl
+++ b/src/DiffEqBiological.jl
@@ -1,12 +1,8 @@
 module DiffEqBiological
 
-using Reexport
-using MacroTools, LinearAlgebra, DataStructures
-using RecipesBase, Latexify
-
-using DiffEqBase, DiffEqJump, ModelingToolkit
-@reexport using DiffEqBase, DiffEqJump, ModelingToolkit
-
+using Reexport, ModelingToolkit
+@reexport using ModelingToolkit
+import MacroTools
 import Base: (==), merge!, merge
 
 const ExprValues = Union{Expr,Symbol,Float64,Int}

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -61,7 +61,7 @@ double_arrows = Set{Symbol}([:↔, :⟷, :⇄, :⇆, :⇔, :⟺])
 pure_rate_arrows = Set{Symbol}([:⇐, :⟽, :⇒, :⟾, :⇔, :⟺])
 
 # Declares symbols which may neither be used as paraemters not varriables.
-forbidden_symbols = [:t, :π, :pi, :ℯ, :im, :I, :nothing, :∅]
+forbidden_symbols = [:t, :π, :pi, :ℯ, :im, :nothing, :∅]
 
 
 ### The main macro, takes reaction network notation and returns a ReactionSystem. ###

--- a/test/make_model.jl
+++ b/test/make_model.jl
@@ -388,4 +388,11 @@ test_network = @reaction_network begin
     (μ,Μ), ω ⟷ Ω
 end α Α β Β γ Γ δ Δ ϵ Ε ζ Ζ η Η θ Θ ι Ι κ Κ λ Λ μ Μ
 
-# Networks containing t, I, im, and π should generate errors.
+# Networks containing t, im, and π should generate errors.
+
+# test I works
+rn = @reaction_network begin
+    k1, S + I --> 2I
+    k2, I --> R
+end k1 k2
+@test isequal(species(rn)[2].name,:I)

--- a/test/plotting.jl
+++ b/test/plotting.jl
@@ -1,3 +1,4 @@
+### Not currently run by runtests 
 ### Fetch required packages and reaction networks ###
 using DiffEqBiological, DiffEqJump, OrdinaryDiffEq, Plots, Random, Test
 include("test_networks.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,8 +27,8 @@ using SafeTestsets
 # Tests related to solvingJump Systems.
 @time @safetestset "Jump System Solving" begin include("solve_jumps.jl") end
 
-# Miscellaneous tests.
-@time @safetestset "Basic Plotting" begin include("plotting.jl") end
+# Miscellaneous tests
+#@time @safetestset "Basic Plotting" begin include("plotting.jl") end
 #@time @safetestset "Latexify" begin include("latexify.jl") end
 
 end # @time


### PR DESCRIPTION
@TorkelE we had discussed adding back in `I`, but I noticed it was not allowed still. Is this there any reason to not allow it? 

I've also removed a large number of package imports that are no longer needed, or only needed in tests. We should let tests finish to confirm I didn't miss anything.